### PR TITLE
new asciiart; more unix-alike percentages; get posh version from os instead of guessing

### DIFF
--- a/screenfetch.ps1
+++ b/screenfetch.ps1
@@ -62,63 +62,63 @@ $UsedRamPercent = "{0:N0}" -f $UsedRamPercent;
 ####### Printing Output #########
 
 # Line 1 - HostName
-Write-Host "                          ,,,;;;1       " -f Cyan -NoNewline;
+Write-Host "                         ....::::       " -f Cyan -NoNewline;
 Write-Host $Username -f red -nonewline; 
 Write-Host "@" -f gray -nonewline; 
 Write-Host $Machine -f red;
 
 # Line 2 - OS
-Write-Host "                ,,;;;101000100001       " -f Cyan -NoNewline;
+Write-Host "                 ....::::::::::::       " -f Cyan -NoNewline;
 Write-Host "OS: " -f Red -NoNewline;
 Write-Host $OS $BitVer;
 
 # Line 3 - Kernel
-Write-Host "     ,,,;;;11   10101001001010010       " -f Cyan -NoNewline;
+Write-Host "        ....:::: ::::::::::::::::       " -f Cyan -NoNewline;
 Write-Host "Kernel: " -f Red -nonewline;
 Write-Host $Kernel;
 
 # Line 4 - Uptime
-Write-Host "0111101000111   10110111101101110       " -f Cyan -NoNewline;
+Write-Host "....:::::::::::: ::::::::::::::::       " -f Cyan -NoNewline;
 Write-Host "Uptime: " -f Red  -nonewline;
 Write-Host $uptime.Days"d " $uptime.Hours"h " $uptime.Minutes"m " $uptime.Seconds"s " -separator "";
 
 # Line 5 - Motherboard
-Write-Host "1111010110101   10010100101011010       " -f Cyan -NoNewline;
+Write-Host ":::::::::::::::: ::::::::::::::::       " -f Cyan -NoNewline;
 Write-Host "Motherboard: " -f Red -nonewline; 
 Write-Host $Motherboard.Manufacturer $Motherboard.Product;
 
 # Line 6 - Shell (Hardcoded since it is unlikely anybody can run this without powershell)
-Write-Host "0101010001010   01010101000101010       " -f Cyan -NoNewline;
+Write-Host ":::::::::::::::: ::::::::::::::::       " -f Cyan -NoNewline;
 Write-Host "Shell: " -f Red -nonewline; 
 Write-Host "PowerShell $($PSVersionTable.PSVersion.ToString())"
 
 # Line 7 - Resolution (for primary monitor only)
-Write-Host "1010101010110   01100001011110100       " -f Cyan -NoNewline;
+Write-Host ":::::::::::::::: ::::::::::::::::       " -f Cyan -NoNewline;
 Write-Host "Resolution: " -f Red -NoNewline; 
 Write-Host $Horizontal "x" $Vertical;
 
 # Line 8 - Windows Manager (HARDCODED, sorry bbzero users)
-Write-Host "1100110111011   01101001001010100       " -f Cyan -NoNewline;
+Write-Host ":::::::::::::::: ::::::::::::::::       " -f Cyan -NoNewline;
 Write-Host "Window Manager: " -f Red -nonewline; 
 Write-Host "DWM";
 
 # Line 10 - Font (HARDCODED)
-Write-Host "                                        " -f Cyan -NoNewline;
+Write-Host "................ ................       " -f Cyan -NoNewline;
 Write-Host "Font: " -f Red -nonewline; 
 Write-Host "Segoe UI";
 
 # Line 11 - CPU
-Write-Host "1100110110101   01000101001101010       " -f Cyan -NoNewline;
+Write-Host ":::::::::::::::: ::::::::::::::::       " -f Cyan -NoNewline;
 Write-Host "CPU: " -f Red -nonewline; 
 Write-Host $CPU;
 
 # Line 12 - GPU
-Write-Host "0011100100011   10010001001011000       " -f Cyan -NoNewline;
+Write-Host ":::::::::::::::: ::::::::::::::::       " -f Cyan -NoNewline;
 Write-Host "GPU: " -f Red -nonewline; 
 Write-Host $GPU;
 
 # Line 13 - Ram
-Write-Host "1010001110101   10100010101001010       " -f Cyan -NoNewline;
+Write-Host ":::::::::::::::: ::::::::::::::::       " -f Cyan -NoNewline;
 Write-Host "RAM: " -f Red -nonewline;
 Write-Host $UsedRam "MB / $TotalRam MB" -NoNewline;
 Write-Host " (" -NoNewline
@@ -126,7 +126,7 @@ Write-Host $UsedRamPercent"%" -f Green -NoNewline;
 Write-Host ")";
 
 # Line 13 - Disk Usage
-Write-Host "1101100001011   10001011010101010       " -f Cyan -NoNewline;
+Write-Host "'''':::::::::::: ::::::::::::::::       " -f Cyan -NoNewline;
 Write-Host "Disk: " -f Red -NoNewline;
 Write-Host $UsedDiskSizeGB"GB" " / " $DiskSizeGB"GB" -NoNewline;
 Write-Host " (" -NoNewline; 
@@ -134,7 +134,7 @@ Write-Host $UsedDiskPercent"%" -f Green -NoNewline;
 Write-Host ")"; 
 
 # Empty Lines
-Write-Host "0010001000101   01010110011010010       " -f Cyan;
-Write-Host "     ``````***01   10100011010010101       " -f Cyan;
-Write-Host "                ``````***10101010101       " -f Cyan;
-Write-Host "                           ``````***       " -f Cyan;
+Write-Host "        '''':::: ::::::::::::::::       " -f Cyan;
+Write-Host "                 ''''::::::::::::       " -f Cyan;
+Write-Host "                         ''''::::       " -f Cyan;
+

--- a/screenfetch.ps1
+++ b/screenfetch.ps1
@@ -84,7 +84,7 @@ Write-Host $Motherboard.Manufacturer $Motherboard.Product;
 # Line 6 - Shell (Hardcoded since it is unlikely anybody can run this without powershell)
 Write-Host ":::::::::::::::: ::::::::::::::::       " -f Cyan -NoNewline;
 Write-Host "Shell: " -f Red -nonewline; 
-Write-Host "Powershell 3.0"
+Write-Host "PowerShell $($PSVersionTable.PSVersion.ToString())"
 
 # Line 7 - Resolution (for primary monitor only)
 Write-Host ":::::::::::::::: ::::::::::::::::       " -f Cyan -NoNewline;

--- a/screenfetch.ps1
+++ b/screenfetch.ps1
@@ -62,63 +62,63 @@ $UsedRamPercent = "{0:N0}" -f $UsedRamPercent;
 ####### Printing Output #########
 
 # Line 1 - HostName
-Write-Host "                         ....::::       " -f Cyan -NoNewline;
+Write-Host "                          ,,,;;;1       " -f Cyan -NoNewline;
 Write-Host $Username -f red -nonewline; 
 Write-Host "@" -f gray -nonewline; 
 Write-Host $Machine -f red;
 
 # Line 2 - OS
-Write-Host "                 ....::::::::::::       " -f Cyan -NoNewline;
+Write-Host "                ,,;;;101000100001       " -f Cyan -NoNewline;
 Write-Host "OS: " -f Red -NoNewline;
 Write-Host $OS $BitVer;
 
 # Line 3 - Kernel
-Write-Host "        ....:::: ::::::::::::::::       " -f Cyan -NoNewline;
+Write-Host "     ,,,;;;11   10101001001010010       " -f Cyan -NoNewline;
 Write-Host "Kernel: " -f Red -nonewline;
 Write-Host $Kernel;
 
 # Line 4 - Uptime
-Write-Host "....:::::::::::: ::::::::::::::::       " -f Cyan -NoNewline;
+Write-Host "0111101000111   10110111101101110       " -f Cyan -NoNewline;
 Write-Host "Uptime: " -f Red  -nonewline;
 Write-Host $uptime.Days"d " $uptime.Hours"h " $uptime.Minutes"m " $uptime.Seconds"s " -separator "";
 
 # Line 5 - Motherboard
-Write-Host ":::::::::::::::: ::::::::::::::::       " -f Cyan -NoNewline;
+Write-Host "1111010110101   10010100101011010       " -f Cyan -NoNewline;
 Write-Host "Motherboard: " -f Red -nonewline; 
 Write-Host $Motherboard.Manufacturer $Motherboard.Product;
 
 # Line 6 - Shell (Hardcoded since it is unlikely anybody can run this without powershell)
-Write-Host ":::::::::::::::: ::::::::::::::::       " -f Cyan -NoNewline;
+Write-Host "0101010001010   01010101000101010       " -f Cyan -NoNewline;
 Write-Host "Shell: " -f Red -nonewline; 
 Write-Host "PowerShell $($PSVersionTable.PSVersion.ToString())"
 
 # Line 7 - Resolution (for primary monitor only)
-Write-Host ":::::::::::::::: ::::::::::::::::       " -f Cyan -NoNewline;
+Write-Host "1010101010110   01100001011110100       " -f Cyan -NoNewline;
 Write-Host "Resolution: " -f Red -NoNewline; 
 Write-Host $Horizontal "x" $Vertical;
 
 # Line 8 - Windows Manager (HARDCODED, sorry bbzero users)
-Write-Host ":::::::::::::::: ::::::::::::::::       " -f Cyan -NoNewline;
+Write-Host "1100110111011   01101001001010100       " -f Cyan -NoNewline;
 Write-Host "Window Manager: " -f Red -nonewline; 
 Write-Host "DWM";
 
 # Line 10 - Font (HARDCODED)
-Write-Host "................ ................       " -f Cyan -NoNewline;
+Write-Host "                                        " -f Cyan -NoNewline;
 Write-Host "Font: " -f Red -nonewline; 
 Write-Host "Segoe UI";
 
 # Line 11 - CPU
-Write-Host ":::::::::::::::: ::::::::::::::::       " -f Cyan -NoNewline;
+Write-Host "1100110110101   01000101001101010       " -f Cyan -NoNewline;
 Write-Host "CPU: " -f Red -nonewline; 
 Write-Host $CPU;
 
 # Line 12 - GPU
-Write-Host ":::::::::::::::: ::::::::::::::::       " -f Cyan -NoNewline;
+Write-Host "0011100100011   10010001001011000       " -f Cyan -NoNewline;
 Write-Host "GPU: " -f Red -nonewline; 
 Write-Host $GPU;
 
 # Line 13 - Ram
-Write-Host ":::::::::::::::: ::::::::::::::::       " -f Cyan -NoNewline;
+Write-Host "1010001110101   10100010101001010       " -f Cyan -NoNewline;
 Write-Host "RAM: " -f Red -nonewline;
 Write-Host $UsedRam "MB / $TotalRam MB" -NoNewline;
 Write-Host " (" -NoNewline
@@ -126,7 +126,7 @@ Write-Host $UsedRamPercent"%" -f Green -NoNewline;
 Write-Host ")";
 
 # Line 13 - Disk Usage
-Write-Host "'''':::::::::::: ::::::::::::::::       " -f Cyan -NoNewline;
+Write-Host "1101100001011   10001011010101010       " -f Cyan -NoNewline;
 Write-Host "Disk: " -f Red -NoNewline;
 Write-Host $UsedDiskSizeGB"GB" " / " $DiskSizeGB"GB" -NoNewline;
 Write-Host " (" -NoNewline; 
@@ -134,7 +134,7 @@ Write-Host $UsedDiskPercent"%" -f Green -NoNewline;
 Write-Host ")"; 
 
 # Empty Lines
-Write-Host "        '''':::: ::::::::::::::::       " -f Cyan;
-Write-Host "                 ''''::::::::::::       " -f Cyan;
-Write-Host "                         ''''::::       " -f Cyan;
-
+Write-Host "0010001000101   01010110011010010       " -f Cyan;
+Write-Host "     ``````***01   10100011010010101       " -f Cyan;
+Write-Host "                ``````***10101010101       " -f Cyan;
+Write-Host "                           ``````***       " -f Cyan;

--- a/screenfetch.ps1
+++ b/screenfetch.ps1
@@ -33,8 +33,12 @@ $FreeDiskSizeGB = "{0:N0}" -f $FreeDiskSizeGB;
 $DiskSize = (gwmi Win32_LogicalDisk).size | select -f 1;
 $DiskSizeGB = $DiskSize / 1073741824;
 $DiskSizeGB = "{0:N0}" -f $DiskSizeGB;
-$DiskPercent = ($FreeDiskSizeGB / $DiskSizeGB) * 100;
-$DiskPercent = "{0:N0}" -f $DiskPercent;
+$FreeDiskPercent = ($FreeDiskSizeGB / $DiskSizeGB) * 100;
+$FreeDiskPercent = "{0:N0}" -f $FreeDiskPercent;
+# Used Space
+$UsedDiskSizeGB = $DiskSizeGB - $FreeDiskSizeGB;
+$UsedDiskPercent = ($UsedDiskSizeGB / $DiskSizeGB) * 100;
+$UsedDiskPercent = "{0:N0}" -f $UsedDiskPercent;
 
 ## Environment Information
 $Username = $env:username;
@@ -49,9 +53,11 @@ $CPU = (((gwmi Win32_Processor).Name) -replace '\s+', ' ');
 $GPU = (gwmi Win32_DisplayConfiguration).DeviceName;
 $FreeRam = ([math]::Truncate((gwmi Win32_OperatingSystem).FreePhysicalMemory / 1KB)); 
 $TotalRam = ([math]::Truncate((gwmi Win32_ComputerSystem).TotalPhysicalMemory / 1MB));
-$RamPercent = ($FreeRam / $TotalRam) * 100;
-$RamPercent = "{0:N0}" -f $RamPercent;
-
+$UsedRam = $TotalRam - $FreeRam;
+$FreeRamPercent = ($FreeRam / $TotalRam) * 100;
+$FreeRamPercent = "{0:N0}" -f $FreeRamPercent;
+$UsedRamPercent = ($UsedRam / $TotalRam) * 100;
+$UsedRamPercent = "{0:N0}" -f $UsedRamPercent;
 
 ####### Printing Output #########
 
@@ -114,17 +120,17 @@ Write-Host $GPU;
 # Line 13 - Ram
 Write-Host ":::::::::::::::: ::::::::::::::::       " -f Cyan -NoNewline;
 Write-Host "RAM: " -f Red -nonewline;
-Write-Host $FreeRam "MB / $TotalRam MB" -NoNewline;
+Write-Host $UsedRam "MB / $TotalRam MB" -NoNewline;
 Write-Host " (" -NoNewline
-Write-Host $RamPercent"%" -f Green -NoNewline;
+Write-Host $UsedRamPercent"%" -f Green -NoNewline;
 Write-Host ")";
 
 # Line 13 - Disk Usage
 Write-Host "'''':::::::::::: ::::::::::::::::       " -f Cyan -NoNewline;
 Write-Host "Disk: " -f Red -NoNewline;
-Write-Host $FreeDiskSizeGB"GB" " / " $DiskSizeGB"GB" -NoNewline;
+Write-Host $UsedDiskSizeGB"GB" " / " $DiskSizeGB"GB" -NoNewline;
 Write-Host " (" -NoNewline; 
-Write-Host $DiskPercent"%" -f Green -NoNewline;
+Write-Host $UsedDiskPercent"%" -f Green -NoNewline;
 Write-Host ")"; 
 
 # Empty Lines


### PR DESCRIPTION
 ### new asciiart  
made from scratch, the shape should be a bit closer to original logo, also more vibrant looking because of character change  
 ### more unix-alike percentages  
since this is more or less a carbon copy of screenfetch i changed ram and disk to show the used instead of free space, that's how it is in the original  
### get posh version from os instead of guessing  
while i agree that powershell can be hard-coded as the shell here, it's version really cannot, there are many versions of posh, and it is very simple to show, so...