### PR TITLE
don't process zero-sized disks

### DIFF
--- a/Data.psm1
+++ b/Data.psm1
@@ -177,7 +177,7 @@ Function Get-Disks()
 
             $DiskSize = (Get-WmiObject Win32_LogicalDisk)[$i].Size;
 
-            if ($DiskSize)
+            if ($DiskSize -and $DiskSize -ne 0)
             {
                 $FreeDiskSize = (Get-WmiObject Win32_LogicalDisk)[$i].FreeSpace
                 $FreeDiskSizeGB = $FreeDiskSize / 1073741824;


### PR DESCRIPTION
See issue #14

Prevents divide by zero exception