### PR TITLE
Resolved #37

### DIFF
--- a/Data.psm1
+++ b/Data.psm1
@@ -5,7 +5,7 @@ Function Get-SystemSpecifications()
     $UserInfo = Get-UserInformation;
     $OS = Get-OS;
     $Kernel = Get-Kernel;
-    $Uptime = Get-Uptime;
+    $Uptime = Get-CurrentUptime;
     $Motherboard = Get-Mobo;
     $Shell = Get-Shell;
     $Displays = Get-Displays;
@@ -75,7 +75,7 @@ Function Get-Kernel()
     return (Get-CimInstance  Win32_OperatingSystem).Version;
 }
 
-Function Get-Uptime()
+Function Get-CurrentUptime()
 {
     $Uptime = (([DateTime](Get-CimInstance Win32_OperatingSystem).LocalDateTime) -
             ([DateTime](Get-CimInstance Win32_OperatingSystem).LastBootUpTime));


### PR DESCRIPTION
Renamed Get-Uptime() to Get-CurrentUptime() to resolve a conflict with already existing pwsh v7 function. This is a dirty hack though.