### PR TITLE
Missing Ascii Art Ending, Display resolution error and get-uptime alias

### DIFF
--- a/Data.psm1
+++ b/Data.psm1
@@ -117,7 +117,10 @@ Function Get-Display()
 
 Function Get-Displays()
 {
-    return Get-Display;
+
+    if ($Displays.Count -eq 1) {
+        return Get-Display
+    }
 
     $Displays = New-Object System.Collections.Generic.List[System.Object];
 
@@ -131,10 +134,6 @@ Function Get-Displays()
         $maxResolutions = $sortedResolutions | Select-Object @{N="MaxRes";E={"$($_.HorizontalActivePixels) x $($_.VerticalActivePixels) "}}
 
         $Displays.Add(($maxResolutions | Select-Object -Last 1).MaxRes);
-    }
-
-    if ($Displays.Count -eq 1) {
-        return Get-Display
     }
 
     return $Displays;

--- a/windows-screenfetch.psm1
+++ b/windows-screenfetch.psm1
@@ -6,18 +6,18 @@ Function Screenfetch($distro)
 {
     $AsciiArt = "";
 
-    if (-not $distro) 
+    if (-not $distro)
     {
         $AsciiArt = . Get-WindowsArt;
     }
 
-    if (([string]::Compare($distro, "mac", $true) -eq 0) -or 
-        ([string]::Compare($distro, "macOS", $true) -eq 0) -or 
+    if (([string]::Compare($distro, "mac", $true) -eq 0) -or
+        ([string]::Compare($distro, "macOS", $true) -eq 0) -or
         ([string]::Compare($distro, "osx", $true) -eq 0)) {
-            
+
         $AsciiArt = . Get-MacArt;
     }
-    else 
+    else
     {
         $AsciiArt = . Get-WindowsArt;
     }
@@ -26,7 +26,7 @@ Function Screenfetch($distro)
     $LineToTitleMappings = . Get-LineToTitleMappings;
 
     # Iterate over all lines from the SystemInfoCollection to display all information
-    for ($line = 0; $line -lt $SystemInfoCollection.Count; $line++) 
+    for ($line = 0; $line -lt $SystemInfoCollection.Count; $line++)
     {
         if (($AsciiArt[$line].Length) -eq 0)
         {
@@ -39,12 +39,12 @@ Function Screenfetch($distro)
         }
         Write-Host $LineToTitleMappings[$line] -f Red -NoNewline;
 
-        if ($line -eq 0) 
+        if ($line -eq 0)
         {
             Write-Host $SystemInfoCollection[$line] -f Red;
         }
 
-        elseif ($SystemInfoCollection[$line] -like '*:*') 
+        elseif ($SystemInfoCollection[$line] -like '*:*')
         {
             $Seperator = ":";
             $Splitted = $SystemInfoCollection[$line].Split($seperator);
@@ -55,9 +55,9 @@ Function Screenfetch($distro)
             Write-Host $Title -f Red -NoNewline;
             Write-Host $Content;
         }
-        else 
+        else
         {
-            Write-Host $SystemInfoCollection[$line];            
+            Write-Host $SystemInfoCollection[$line];
         }
     }
 }

--- a/windows-screenfetch.psm1
+++ b/windows-screenfetch.psm1
@@ -36,29 +36,33 @@ Function Screenfetch($distro)
         else
         {
             Write-Host $AsciiArt[$line] -f Cyan -NoNewline;
-        }
-        Write-Host $LineToTitleMappings[$line] -f Red -NoNewline;
+            Write-Host $LineToTitleMappings[$line] -f Red -NoNewline;
 
-        if ($line -eq 0)
-        {
-            Write-Host $SystemInfoCollection[$line] -f Red;
-        }
+            if ($line -eq 0)
+            {
+                Write-Host $SystemInfoCollection[$line] -f Red;
+            }
+            elseif ($SystemInfoCollection[$line] -like '*:*')
+            {
+                $Seperator = ":";
+                $Splitted = $SystemInfoCollection[$line].Split($seperator);
 
-        elseif ($SystemInfoCollection[$line] -like '*:*')
-        {
-            $Seperator = ":";
-            $Splitted = $SystemInfoCollection[$line].Split($seperator);
+                $Title = $Splitted[0] + $Seperator;
+                $Content = $Splitted[1];
 
-            $Title = $Splitted[0] + $Seperator;
-            $Content = $Splitted[1];
-
-            Write-Host $Title -f Red -NoNewline;
-            Write-Host $Content;
-        }
-        else
-        {
-            Write-Host $SystemInfoCollection[$line];
+                Write-Host $Title -f Red -NoNewline;
+                Write-Host $Content;
+            }
+            else
+            {
+                Write-Host $SystemInfoCollection[$line];
+            }
+            if (($SystemInfoCollection.Count -eq $line+1) -And
+                ($AsciiArt.Count -gt $SystemInfoCollection.Count)) {
+                for ($continue = $line; $continue -lt $AsciiArt.Count; $continue++) {
+                    Write-Host $AsciiArt[$continue] -f Cyan;
+                }
+            }
         }
     }
 }
-

--- a/windows-screenfetch.psm1
+++ b/windows-screenfetch.psm1
@@ -59,7 +59,7 @@ Function Screenfetch($distro)
             }
             if (($SystemInfoCollection.Count -eq $line+1) -And
                 ($AsciiArt.Count -gt $SystemInfoCollection.Count)) {
-                for ($continue = $line; $continue -lt $AsciiArt.Count; $continue++) {
+                for ($continue = $line+1; $continue -lt $AsciiArt.Count; $continue++) {
                     Write-Host $AsciiArt[$continue] -f Cyan;
                 }
             }


### PR DESCRIPTION
I know, I know this does look like a lot, but if you ignore the trailing white-spaces my vscode removes automatically when saving, the PR actually is not that much.

1. I use a slightly different approach to get-uptime to address #37 and have a backwards compatible way of doing so.
1. I do a check after all SystemInfoCollection was printed out to finalize the ascii art.
1. I also fix  #35 (at least for me). I have the assumption that the snippet

```Function Get-Displays()
{
    return Get-Display;
[...]
```

simply was a unseen missing deletion or copy/past mistake. So I removed it and now it is working again.
Additionally I put the "if single monitor"  statement above the rest to get a tiny bit of speed improvement here for single monitor users.

I hope the code style etc. is fine for you.
If you want some adjustments please tell me!