### PR TITLE
Resolution

### DIFF
--- a/Data.psm1
+++ b/Data.psm1
@@ -177,18 +177,18 @@ Function Get-Disks()
             if ($DiskSize -gt 0) {
                 $FreeDiskSize = (Get-CimInstance Win32_LogicalDisk)[$i].FreeSpace
                 $FreeDiskSizeGB = $FreeDiskSize / 1073741824;
-                $FreeDiskSizeGB = "{0:N0}" -f $FreeDiskSizeGB;
+                $FreeDiskSizeGB = "{0:F0}" -f $FreeDiskSizeGB;
 
                 $DiskSizeGB = $DiskSize / 1073741824;
-                $DiskSizeGB = "{0:N0}" -f $DiskSizeGB;
+                $DiskSizeGB = "{0:F0}" -f $DiskSizeGB;
 
                 if ($DiskSizeGB -gt 0 -And $FreeDiskSizeGB -gt 0) {
                     $FreeDiskPercent = ($FreeDiskSizeGB / $DiskSizeGB) * 100;
-                    $FreeDiskPercent = "{0:N0}" -f $FreeDiskPercent;
+                    $FreeDiskPercent = "{0:F0}" -f $FreeDiskPercent;
 
                     $UsedDiskSizeGB = $DiskSizeGB - $FreeDiskSizeGB;
                     $UsedDiskPercent = ($UsedDiskSizeGB / $DiskSizeGB) * 100;
-                    $UsedDiskPercent = "{0:N0}" -f $UsedDiskPercent;
+                    $UsedDiskPercent = "{0:F0}" -f $UsedDiskPercent;
                 }
                 else {
                     $FreeDiskPercent = 0;
@@ -205,8 +205,8 @@ Function Get-Disks()
             }
 
             $FormattedDisk = "Disk " + $DiskID.ToString() + " " + 
-                $UsedDiskSizeGB.ToString() + "GB" + " / " + $DiskSizeGB.ToString() + "GB " + 
-                "(" + $UsedDiskPercent.ToString() + "%" + ")";
+                $UsedDiskSizeGB.ToString("D4") + " GB" + " / " + $DiskSizeGB.ToString() + " GB " + 
+                " (" + $UsedDiskPercent.ToString() + "%" + ")";
             $FormattedDisks.Add($FormattedDisk);
         }
     }
@@ -215,23 +215,23 @@ Function Get-Disks()
 
         $FreeDiskSize = (Get-CimInstance Win32_LogicalDisk).FreeSpace
         $FreeDiskSizeGB = $FreeDiskSize / 1073741824;
-        $FreeDiskSizeGB = "{0:N0}" -f $FreeDiskSizeGB;
+        $FreeDiskSizeGB = "{0:F0}" -f $FreeDiskSizeGB;
 
         $DiskSize = (Get-CimInstance Win32_LogicalDisk).Size;
         $DiskSizeGB = $DiskSize / 1073741824;
-        $DiskSizeGB = "{0:N0}" -f $DiskSizeGB;
+        $DiskSizeGB = "{0:F0}" -f $DiskSizeGB;
 
         if ($DiskSize -gt 0 -And $FreeDiskSize -gt 0 ) {
             $FreeDiskPercent = ($FreeDiskSizeGB / $DiskSizeGB) * 100;
-            $FreeDiskPercent = "{0:N0}" -f $FreeDiskPercent;
+            $FreeDiskPercent = "{0:F0}" -f $FreeDiskPercent;
 
             $UsedDiskSizeGB = $DiskSizeGB - $FreeDiskSizeGB;
             $UsedDiskPercent = ($UsedDiskSizeGB / $DiskSizeGB) * 100;
-            $UsedDiskPercent = "{0:N0}" -f $UsedDiskPercent;
+            $UsedDiskPercent = "{0:F0}" -f $UsedDiskPercent;
 
             $FormattedDisk = "Disk " + $DiskID.ToString() + " " +
-                $UsedDiskSizeGB.ToString() + "GB" + " / " + $DiskSizeGB.ToString() + "GB " +
-                "(" + $UsedDiskPercent.ToString() + "%" + ")";
+                $UsedDiskSizeGB.ToString() + " GB" + " / " + $DiskSizeGB.ToString() + " GB " +
+                " (" + $UsedDiskPercent.ToString() + "%" + ")";
             $FormattedDisks.Add($FormattedDisk);
         } 
         else {

--- a/Data.psm1
+++ b/Data.psm1
@@ -100,7 +100,7 @@ Function Get-Display()
 {
     # This gives the current resolution
     $videoMode = Get-CimInstance -Class Win32_VideoController;
-    $Display = ([string]$videoMode.CurrentHorizontalResolution).Trim() + " x " + ([string]$videoMode.CurrentVerticalResolution).Trim() + " (" + ([string]$videoMode.CurrentRefreshRate).Trim() + "Hz)"
+    $Display = $videoMode.CurrentHorizontalResolution.ToString() + " x " + $videoMode.CurrentVerticalResolution.ToString() + " (" + $videoMode.CurrentRefreshRate.ToString() + "Hz)";
     return $Display;
 }
 

--- a/Data.psm1
+++ b/Data.psm1
@@ -100,7 +100,7 @@ Function Get-Display()
 {
     # This gives the current resolution
     $videoMode = Get-CimInstance -Class Win32_VideoController;
-    $Display = $videoMode.CurrentHorizontalResolution.ToString() + " x " + $videoMode.CurrentVerticalResolution.ToString() + " (" + $videoMode.CurrentRefreshRate.ToString() + "Hz)";
+    $Display = ([string]$videoMode.CurrentHorizontalResolution).Trim() + " x " + ([string]$videoMode.CurrentVerticalResolution).Trim() + " (" + ([string]$videoMode.CurrentRefreshRate).Trim() + "Hz)"
     return $Display;
 }
 
@@ -177,18 +177,18 @@ Function Get-Disks()
             if ($DiskSize -gt 0) {
                 $FreeDiskSize = (Get-CimInstance Win32_LogicalDisk)[$i].FreeSpace
                 $FreeDiskSizeGB = $FreeDiskSize / 1073741824;
-                $FreeDiskSizeGB = "{0:F0}" -f $FreeDiskSizeGB;
+                $FreeDiskSizeGB = "{0:N0}" -f $FreeDiskSizeGB;
 
                 $DiskSizeGB = $DiskSize / 1073741824;
-                $DiskSizeGB = "{0:F0}" -f $DiskSizeGB;
+                $DiskSizeGB = "{0:N0}" -f $DiskSizeGB;
 
                 if ($DiskSizeGB -gt 0 -And $FreeDiskSizeGB -gt 0) {
                     $FreeDiskPercent = ($FreeDiskSizeGB / $DiskSizeGB) * 100;
-                    $FreeDiskPercent = "{0:F0}" -f $FreeDiskPercent;
+                    $FreeDiskPercent = "{0:N0}" -f $FreeDiskPercent;
 
                     $UsedDiskSizeGB = $DiskSizeGB - $FreeDiskSizeGB;
                     $UsedDiskPercent = ($UsedDiskSizeGB / $DiskSizeGB) * 100;
-                    $UsedDiskPercent = "{0:F0}" -f $UsedDiskPercent;
+                    $UsedDiskPercent = "{0:N0}" -f $UsedDiskPercent;
                 }
                 else {
                     $FreeDiskPercent = 0;
@@ -205,8 +205,8 @@ Function Get-Disks()
             }
 
             $FormattedDisk = "Disk " + $DiskID.ToString() + " " + 
-                $UsedDiskSizeGB.ToString("D4") + " GB" + " / " + $DiskSizeGB.ToString() + " GB " + 
-                " (" + $UsedDiskPercent.ToString() + "%" + ")";
+                $UsedDiskSizeGB.ToString() + "GB" + " / " + $DiskSizeGB.ToString() + "GB " + 
+                "(" + $UsedDiskPercent.ToString() + "%" + ")";
             $FormattedDisks.Add($FormattedDisk);
         }
     }
@@ -215,23 +215,23 @@ Function Get-Disks()
 
         $FreeDiskSize = (Get-CimInstance Win32_LogicalDisk).FreeSpace
         $FreeDiskSizeGB = $FreeDiskSize / 1073741824;
-        $FreeDiskSizeGB = "{0:F0}" -f $FreeDiskSizeGB;
+        $FreeDiskSizeGB = "{0:N0}" -f $FreeDiskSizeGB;
 
         $DiskSize = (Get-CimInstance Win32_LogicalDisk).Size;
         $DiskSizeGB = $DiskSize / 1073741824;
-        $DiskSizeGB = "{0:F0}" -f $DiskSizeGB;
+        $DiskSizeGB = "{0:N0}" -f $DiskSizeGB;
 
         if ($DiskSize -gt 0 -And $FreeDiskSize -gt 0 ) {
             $FreeDiskPercent = ($FreeDiskSizeGB / $DiskSizeGB) * 100;
-            $FreeDiskPercent = "{0:F0}" -f $FreeDiskPercent;
+            $FreeDiskPercent = "{0:N0}" -f $FreeDiskPercent;
 
             $UsedDiskSizeGB = $DiskSizeGB - $FreeDiskSizeGB;
             $UsedDiskPercent = ($UsedDiskSizeGB / $DiskSizeGB) * 100;
-            $UsedDiskPercent = "{0:F0}" -f $UsedDiskPercent;
+            $UsedDiskPercent = "{0:N0}" -f $UsedDiskPercent;
 
             $FormattedDisk = "Disk " + $DiskID.ToString() + " " +
-                $UsedDiskSizeGB.ToString() + " GB" + " / " + $DiskSizeGB.ToString() + " GB " +
-                " (" + $UsedDiskPercent.ToString() + "%" + ")";
+                $UsedDiskSizeGB.ToString() + "GB" + " / " + $DiskSizeGB.ToString() + "GB " +
+                "(" + $UsedDiskPercent.ToString() + "%" + ")";
             $FormattedDisks.Add($FormattedDisk);
         } 
         else {

--- a/Data.psm1
+++ b/Data.psm1
@@ -100,7 +100,7 @@ Function Get-Display()
 {
     # This gives the current resolution
     $videoMode = Get-CimInstance -Class Win32_VideoController;
-    $Display = $videoMode.CurrentHorizontalResolution.ToString() + " x " + $videoMode.CurrentVerticalResolution.ToString() + " (" + $videoMode.CurrentRefreshRate.ToString() + "Hz)";
+    $Display = ([string]$videoMode.CurrentHorizontalResolution).Trim() + " x " + ([string]$videoMode.CurrentVerticalResolution).Trim() + " (" + ([string]$videoMode.CurrentRefreshRate).Trim() + "Hz)"
     return $Display;
 }
 


### PR DESCRIPTION
The Resolution property used to display "System.Object[] +  x  + System.Object[] +  ( + System.Object[] + Hz)" using Powershell v.7.0.3. Removing the ToString() function left the value with leading spaces, fixed by using Trim.
The fix was tested in Powershell version 7.0.3 and 5.1.