### PR TITLE
🐞 fix(Data.psm1): Resolve bug

### DIFF
--- a/Data.psm1
+++ b/Data.psm1
@@ -1,5 +1,5 @@
 
-Function Get-SystemSpecifications() 
+Function Get-SystemSpecifications()
 {
 
     $UserInfo = Get-UserInformation;
@@ -17,9 +17,9 @@ Function Get-SystemSpecifications()
     $Disks = Get-Disks;
 
 
-    [System.Collections.ArrayList] $SystemInfoCollection = 
-        $UserInfo, 
-        $OS, 
+    [System.Collections.ArrayList] $SystemInfoCollection =
+        $UserInfo,
+        $OS,
         $Kernel,
         $Uptime,
         $Motherboard,
@@ -35,15 +35,15 @@ Function Get-SystemSpecifications()
     {
         [void]$SystemInfoCollection.Add($Disk);
     }
-    
+
     return $SystemInfoCollection;
 }
 
-Function Get-LineToTitleMappings() 
-{ 
+Function Get-LineToTitleMappings()
+{
     $TitleMappings = @{
         0 = "";
-        1 = "OS: "; 
+        1 = "OS: ";
         2 = "Kernel: ";
         3 = "Uptime: ";
         4 = "Motherboard: ";
@@ -66,7 +66,7 @@ Function Get-UserInformation()
 
 Function Get-OS()
 {
-    return (Get-CimInstance Win32_OperatingSystem).Caption + " " + 
+    return (Get-CimInstance Win32_OperatingSystem).Caption + " " +
         (Get-CimInstance Win32_OperatingSystem).OSArchitecture;
 }
 
@@ -113,7 +113,7 @@ Function Get-Displays()
     # This gives the available resolutions
     $monitors = Get-CimInstance -N "root\wmi" -Class WmiMonitorListedSupportedSourceModes
 
-    foreach($monitor in $monitors) 
+    foreach($monitor in $monitors)
     {
         # Sort the available modes by display area (width*height)
         $sortedResolutions = $monitor.MonitorSourceModes | Sort-Object -Property {$_.HorizontalActivePixels * $_.VerticalActivePixels}
@@ -129,29 +129,29 @@ Function Get-Displays()
     return $Displays;
 }
 
-Function Get-WM() 
+Function Get-WM()
 {
     return "DWM";
 }
 
-Function Get-Font() 
+Function Get-Font()
 {
     return "Segoe UI";
 }
 
-Function Get-CPU() 
+Function Get-CPU()
 {
     return (((Get-CimInstance Win32_Processor).Name) -replace '\s+', ' ');
 }
 
-Function Get-GPU() 
+Function Get-GPU()
 {
     return (Get-CimInstance Win32_DisplayConfiguration).DeviceName;
 }
 
-Function Get-RAM() 
+Function Get-RAM()
 {
-    $FreeRam = ([math]::Truncate((Get-CimInstance Win32_OperatingSystem).FreePhysicalMemory / 1KB)); 
+    $FreeRam = ([math]::Truncate((Get-CimInstance Win32_OperatingSystem).FreePhysicalMemory / 1KB));
     $TotalRam = ([math]::Truncate((Get-CimInstance Win32_ComputerSystem).TotalPhysicalMemory / 1MB));
     $UsedRam = $TotalRam - $FreeRam;
     $FreeRamPercent = ($FreeRam / $TotalRam) * 100;
@@ -162,8 +162,8 @@ Function Get-RAM()
     return $UsedRam.ToString() + "MB / " + $TotalRam.ToString() + " MB " + "(" + $UsedRamPercent.ToString() + "%" + ")";
 }
 
-Function Get-Disks() 
-{     
+Function Get-Disks()
+{
     $FormattedDisks = New-Object System.Collections.Generic.List[System.Object];
 
     $NumDisks = (Get-CimInstance Win32_LogicalDisk).Count;
@@ -172,7 +172,7 @@ Function Get-Disks()
         for ($i=0; $i -lt ($NumDisks); $i++) {
             $DiskID = (Get-CimInstance Win32_LogicalDisk)[$i].DeviceId;
 
-            $DiskSize = (Get-CimInstance Win32_LogicalDisk)[$i].Size;
+            $DiskSize = (Get-WmiObject Win32_LogicalDisk).Size[0];
 
             if ($DiskSize -gt 0) {
                 $FreeDiskSize = (Get-CimInstance Win32_LogicalDisk)[$i].FreeSpace
@@ -204,8 +204,8 @@ Function Get-Disks()
                 $UsedDiskPercent = 100;
             }
 
-            $FormattedDisk = "Disk " + $DiskID.ToString() + " " + 
-                $UsedDiskSizeGB.ToString() + "GB" + " / " + $DiskSizeGB.ToString() + "GB " + 
+            $FormattedDisk = "Disk " + $DiskID.ToString() + " " +
+                $UsedDiskSizeGB.ToString() + "GB" + " / " + $DiskSizeGB.ToString() + "GB " +
                 "(" + $UsedDiskPercent.ToString() + "%" + ")";
             $FormattedDisks.Add($FormattedDisk);
         }
@@ -233,7 +233,7 @@ Function Get-Disks()
                 $UsedDiskSizeGB.ToString() + "GB" + " / " + $DiskSizeGB.ToString() + "GB " +
                 "(" + $UsedDiskPercent.ToString() + "%" + ")";
             $FormattedDisks.Add($FormattedDisk);
-        } 
+        }
         else {
             $FormattedDisk = "Disk " + $DiskID.ToString() + " Empty";
             $FormattedDisks.Add($FormattedDisk);


### PR DESCRIPTION
I got a divide by zero error in my Windows 11 pro OS.
As you can see, my programming skills are very poor. If I change something wrong, please point it out.
Here is the error message。

❯ Screenfetch 
try to devide zero. location C:\Program Files\WindowsPowerShell\Modules\windows-screenfetch\1.0.2\Data.psm1:174 char: 13 +             $FreeDiskPercent = ($FreeDiskSizeGB / $DiskSizeGB) * 100; +             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~     + CategoryInfo          : NotSpecified: (:) [], RuntimeException     + FullyQualifiedErrorId : RuntimeException  try to devide zero. location C:\Program Files\WindowsPowerShell\Modules\windows-screenfetch\1.0.2\Data.psm1:178 char: 13 +             $UsedDiskPercent = ($UsedDiskSizeGB / $DiskSizeGB) * 100; +             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~     + CategoryInfo          : NotSpecified: (:) [], RuntimeException     + FullyQualifiedErrorId : RuntimeException  try to devide zero. location C:\Program Files\WindowsPowerShell\Modules\windows-screenfetch\1.0.2\Data.psm1:174 char: 13 +             $FreeDiskPercent = ($FreeDiskSizeGB / $DiskSizeGB) * 100; +             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~     + CategoryInfo          : NotSpecified: (:) [], RuntimeException     + FullyQualifiedErrorId : RuntimeException  try to devide zero. location C:\Program Files\WindowsPowerShell\Modules\windows-screenfetch\1.0.2\Data.psm1:178 char: 13 +             $UsedDiskPercent = ($UsedDiskSizeGB / $DiskSizeGB) * 100; +             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~     + CategoryInfo          : NotSpecified: (:) [], RuntimeException     + FullyQualifiedErrorId : RuntimeException                           ....::::       Admin@EVANGELIONSP                  ....::::::::::::       OS: Microsoft Windows 11 pro 64 bit         ....:::: ::::::::::::::::       Kernel: 10.0.22000 ....:::::::::::: ::::::::::::::::       Uptime: 0d 17h 26m 11s :::::::::::::::: ::::::::::::::::       Motherboard: Microsoft Corporation Surface Pro 7 :::::::::::::::: ::::::::::::::::       Shell: PowerShell 5.1.22000.282 :::::::::::::::: ::::::::::::::::       Resolution: 2736 x 1824 :::::::::::::::: ::::::::::::::::       Window Manager: DWM ................ ................       Font: Segoe UI :::::::::::::::: ::::::::::::::::       CPU: Intel(R) Core(TM) i7-1065G7 CPU @ 1.30GHz :::::::::::::::: ::::::::::::::::       GPU Intel(R) Iris(R) Plus Graphics :::::::::::::::: ::::::::::::::::       RAM: 5980MB / 15970 MB (37%) '''':::::::::::: ::::::::::::::::       Disk C: 82GB / 237GB (35%)         '''':::: ::::::::::::::::       Disk D: 0GB / 119GB (0%)                  ''''::::::::::::       Disk E: 0GB / 0GB (0%)                          ''''::::       Disk F: 0GB / 0GB (0%)       Admin@EvangelionSP  ~  ❯ Screenfetch try to devide zero. location C:\Program Files\WindowsPowerShell\Modules\windows-screenfetch\1.0.2\Data.psm1:174 char: 13 +             $FreeDiskPercent = ($FreeDiskSizeGB / $DiskSizeGB) * 100; +             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~     + CategoryInfo          : NotSpecified: (:) [], RuntimeException     + FullyQualifiedErrorId : RuntimeException  try to devide zero. location C:\Program Files\WindowsPowerShell\Modules\windows-screenfetch\1.0.2\Data.psm1:178 char: 13 +             $UsedDiskPercent = ($UsedDiskSizeGB / $DiskSizeGB) * 100; +             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~     + CategoryInfo          : NotSpecified: (:) [], RuntimeException     + FullyQualifiedErrorId : RuntimeException  try to devide zero. location C:\Program Files\WindowsPowerShell\Modules\windows-screenfetch\1.0.2\Data.psm1:174 char: 13 +             $FreeDiskPercent = ($FreeDiskSizeGB / $DiskSizeGB) * 100; +             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~     + CategoryInfo          : NotSpecified: (:) [], RuntimeException     + FullyQualifiedErrorId : RuntimeException  try to devide zero. location C:\Program Files\WindowsPowerShell\Modules\windows-screenfetch\1.0.2\Data.psm1:178 char: 13 +             $UsedDiskPercent = ($UsedDiskSizeGB / $DiskSizeGB) * 100; +             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~     + CategoryInfo          : NotSpecified: (:) [], RuntimeException     + FullyQualifiedErrorId : RuntimeException                           ....::::       Admin@EVANGELIONSP                  ....::::::::::::       OS: Microsoft Windows 11 pro 64 位         ....:::: ::::::::::::::::       Kernel: 10.0.22000 ....:::::::::::: ::::::::::::::::       Uptime: 0d 17h 35m 27s :::::::::::::::: ::::::::::::::::       Motherboard: Microsoft Corporation Surface Pro 7 :::::::::::::::: ::::::::::::::::       Shell: PowerShell 5.1.22000.282 :::::::::::::::: ::::::::::::::::       Resolution: 2736 x 1824 :::::::::::::::: ::::::::::::::::       Window Manager: DWM ................ ................       Font: Segoe UI :::::::::::::::: ::::::::::::::::       CPU: Intel(R) Core(TM) i7-1065G7 CPU @ 1.30GHz :::::::::::::::: ::::::::::::::::       GPU Intel(R) Iris(R) Plus Graphics :::::::::::::::: ::::::::::::::::       RAM: 7471MB / 15970 MB (47%) '''':::::::::::: ::::::::::::::::       Disk C: 83GB / 237GB (35%)         '''':::: ::::::::::::::::       Disk D: 0GB / 119GB (0%)                  ''''::::::::::::       Disk E: 0GB / 0GB (0%)                          ''''::::       Disk F: 0GB / 0GB (0%)